### PR TITLE
Quiz Screen Backend

### DIFF
--- a/Carbon/navigation/screens/Main/MainContainer.js
+++ b/Carbon/navigation/screens/Main/MainContainer.js
@@ -10,7 +10,7 @@ import { Colors } from '../../../colors/Colors';
 import { IconNames } from './IconNames';
 
 import { ScreenNames } from './ScreenNames';
-import { HomeScreen, ProgressScreen, ForumScreen, RankingScreen, SettingsScreen, AddProgress } from '../../screens';
+import { HomeScreen, ProgressScreen, ForumScreen, RankingScreen, SettingsScreen, QuizScreen, AddProgress } from '../../screens';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -104,7 +104,8 @@ const ForumStack = ({ navigation }) => {
         <Stack.Navigator>
             <Stack.Screen
                 name={' '}
-                component={ForumScreen}
+                //component={ForumScreen}
+                component={QuizScreen}
                 options={{
                     headerShown: false, // Set to false for now until we need to implement headers for this screen
                 }}

--- a/Carbon/navigation/screens/Main/ScreenNames.js
+++ b/Carbon/navigation/screens/Main/ScreenNames.js
@@ -5,4 +5,5 @@ export const ScreenNames = {
     RANKING: 'Ranking',
     SETTINGS: 'Settings',
     ADD_PROGRESS: 'AddProgress',
+    QUIZ: 'Quiz'
 };

--- a/Carbon/navigation/screens/Quiz/QuizScreen.js
+++ b/Carbon/navigation/screens/Quiz/QuizScreen.js
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { ActivityIndicator, Alert, FlatList, SafeAreaView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {useState, useEffect} from 'react';
+import { RadioButton } from 'react-native-paper';
+
+//eventually will be changed to server url
+const APIURL = "http://localhost:3000/api/quiz/1"
+
+const QuizScreen = () => {
+    //used for fetching data 
+    const[isLoading, setLoading] = useState(true);
+    const[data, setData] = useState([]);
+    const[question, setQuestion] = useState([]);
+
+
+    //gets all content from quizcontent
+    const fetchData = async() => {
+        console.log("Fetching data for quizcontent");
+        try{
+        const response = await fetch(APIURL)
+        const responsedata = await response.json();
+        setData(responsedata.quiz);
+        setLoading(false);
+
+        }
+        catch(error) {
+            console.error("An error occured when connecting to the api, ensure you turned on the server and updated the APIURL accordingly if hosting localy - Avery. The following is the official error message: " + error)
+        }
+    };
+
+    useEffect(() => {
+        fetchData();
+    }, []);
+
+    //sets score and current question to 0 
+    const [score, setScore] = useState(0);
+    const [currentQuestion, setCurrentQuestion] = useState(0);
+    const [quizCompleted, setQuizCompleted] = useState(false);
+
+    //HELPER FUNCTIONS
+    const answerClicked = (isCorrect) => {
+        if(isCorrect){
+            setScore(score+1);
+        }
+        
+        if(currentQuestion + 1 < data.questions.length){
+            setCurrentQuestion(currentQuestion + 1);
+        }
+        else{
+            setQuizCompleted(true)
+        }
+    }
+
+    //BEGINNING OF DISPLAY
+    return(
+        <SafeAreaView>
+            <View>
+                {isLoading ? (
+                <View>
+                    <Text>Loading</Text>
+                </View>
+                ) : (
+                <View>
+                    <Text>{data.quizname}</Text>
+
+                    {quizCompleted ? (
+                        <View>
+                        <Text>Quiz Done</Text>
+                        <Text>Final Score: {score}/{data.questions.length}</Text>
+                        </View>
+                    ) : (
+                        <View>
+                        <Text>Current Score: {score}</Text>
+                        <Text>Question {currentQuestion + 1} out of {data.questions.length}</Text>
+                        <Text>{data.questions[currentQuestion].question}</Text>
+                        {data.questions[currentQuestion].answers.map((answer) => (
+                            <TouchableOpacity 
+                            onPress={() => answerClicked(answer.iscorrect)}>
+                                <Text>{answer.answer}</Text>
+                            </TouchableOpacity>
+                        ))
+                        }
+                        </View>
+                    )}
+                </View>
+                )}
+            </View>
+        </SafeAreaView>
+    )
+    
+}
+    
+    export default QuizScreen;

--- a/Carbon/navigation/screens/index.js
+++ b/Carbon/navigation/screens/index.js
@@ -3,4 +3,5 @@ export {default as ProgressScreen} from './Progress/ProgressScreen';
 export {default as ForumScreen} from './Forum/ForumScreen';
 export {default as RankingScreen} from './Ranking/RankingScreen';
 export {default as SettingsScreen} from './Settings/SettingsScreen';
+export {default as QuizScreen} from './Quiz/QuizScreen';
 // export {default as AddProgress} from './Progress/AddProgress';


### PR DESCRIPTION
This pull request adds the quizScreen component to the forum tab. Currently, this is the only screen in the stack, making it the main component of the feature.

The quizScreen component is designed to read data from the local API. If the API is not active, it displays an error message and shows a loading indicator. Once it fetches the data, the component goes through all the questions, incrementing the score if the answer is correct. When there are no more questions, it displays a "Done" message.

This is backend heavy and the Quiz Screen will have front end updates down the line. 

Overall, this feature adds an interactive and engaging element to the forum tab, which will enhance the user experience. It has been tested thoroughly, and all functionality is working as expected. Please review and merge this pull request if everything meets the project's standards.