### PR TITLE
Added Emission Modal and Record Emission Component

### DIFF
--- a/Carbon/navigation/screens/Progress/EmissionModal.js
+++ b/Carbon/navigation/screens/Progress/EmissionModal.js
@@ -1,0 +1,108 @@
+import React, {useState} from 'react';
+import { StyleSheet, Modal, Text, View, Pressable, TextInput, ToastAndroid } from 'react-native';
+import Icon from 'react-native-vector-icons/FontAwesome';
+
+const EmissionModal = ({visible, onRequestClose, title, saveData}) => {
+  const [log, setLog] = useState('');  
+  const showToast = () => {
+    ToastAndroid.show("Emission saved successfully", ToastAndroid.SHORT);
+  }
+  return (
+        <Modal
+          style={styles.modal}
+          animationType="slide"
+          transparent={true}
+          backdropOpacity={0}
+          visible={visible}
+          onRequestClose={() => {
+            setLog('');
+            onRequestClose();
+          }}
+        >
+          <View style={styles.centeredView}>
+            <View style={styles.modalView}>
+              <Text style={styles.modalText}>{title}</Text>
+              <View style={styles.textInput}>
+                <TextInput  onChangeText={text => setLog(text)} />
+              </View>
+              <Pressable onPress={() => {
+                saveData(log)
+                showToast();
+                onRequestClose();
+              }}>
+            <Icon name="save" size={40} color="#201B1B" style={styles.icon} />
+
+            </Pressable>
+
+            <Pressable
+                  onPress={() => {
+                  setLog('');
+                  onRequestClose();
+                }}
+            >
+            <Icon name="close" size={40} color="#201B1B" style={styles.icon} />
+
+              </Pressable>
+            </View>
+          </View>
+        </Modal>
+      );
+    };
+
+export default EmissionModal;
+
+const styles = StyleSheet.create({
+    centeredView: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginTop: 22,
+        justifyContent: 'flex-end',
+        marginBottom: 48 ,
+      },
+
+    modalView: {
+        width: "100%",
+        height: "50%",
+        borderTopStartRadius: 12,
+        borderTopEndRadius: 12,
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: '#B2E4EE',
+        shadowOpacity: 0.25,
+        shadowRadius: 4,
+        elevation: 5,
+    },
+    
+    text: {
+      textAlign: 'center',
+    },
+    textInput: {
+      width: 100,
+      height: 30,
+      fontSize: 12,
+      borderRadius: 8,
+      borderWidth: 2,
+      elevation: 2,
+      borderColor: '#201B1B',
+      backgroundColor: 'white',
+    },
+    button: {
+        borderRadius: 4,
+        borderWidth: 2,
+        borderColor: 'black',
+        padding: 10,
+        margin: 10,
+        elevation: 2,
+        width: 120,
+      },
+
+      modalText: {
+        marginBottom: 15,
+        textAlign: 'center',
+      },
+      icon: {
+        paddingBottom: 10,
+        paddingTop: 5
+      }
+})

--- a/Carbon/navigation/screens/Progress/ProgressScreen.js
+++ b/Carbon/navigation/screens/Progress/ProgressScreen.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { View, Text } from 'react-native';
+import RecordEmission from './RecordEmission';
 
 export default function ProgressScreen({navigation}) {
     return(
@@ -21,6 +22,7 @@ export default function ProgressScreen({navigation}) {
             >
                 Progress Screen
             </Text>
+            <RecordEmission />
         </View>
     )
 }

--- a/Carbon/navigation/screens/Progress/RecordEmission.js
+++ b/Carbon/navigation/screens/Progress/RecordEmission.js
@@ -1,0 +1,147 @@
+import { StyleSheet, Text, TextInput, View, Pressable, Modal, KeyboardAvoidingView } from 'react-native'
+import {React, useState} from 'react'
+import EmissionModal from './EmissionModal';
+import Icon from 'react-native-vector-icons/FontAwesome';
+
+const RecordEmission = () => {
+  const [modalVisible, setModalVisible] = useState(false);
+  const [foodVisible, setFoodVisible] = useState(false);
+  const [transportationVisible, setTransportationVisible] = useState(false);
+  const [recyclingVisible, setRecyclingVisible] = useState(false);
+
+  
+  //TODO: Sanitize and save input to database
+  
+  const saveFoodLog = (log) => {
+    console.log('saving food ' + log);
+  }
+  const saveTransportationLog = (log) => {
+    console.log('saving transportation ' + log);
+  }
+
+  const saveRecyclingLog = (log) => {
+    console.log('saving recycling ' + log);
+  }
+  return (
+    <KeyboardAvoidingView >
+        <Modal style={styles.modal}
+        animationType="fade"
+        transparent={true}
+        presentationStyle={'overFullScreen'}
+        backdropOpacity={50}
+        visible={modalVisible}
+        onRequestClose={() => {
+          setModalVisible(!modalVisible);
+        }}>
+        <View style={styles.centeredView}>
+          <View style={styles.modalView}>
+
+            <Pressable onPress={() => {
+                setModalVisible(!modalVisible)
+                setFoodVisible(true)}
+            }>
+              <Icon name="cutlery" size={40} color="#201B1B" style={styles.icon} />
+            </Pressable>
+
+            <Pressable onPress={() => {
+                setModalVisible(!modalVisible)
+                setTransportationVisible(true)
+            }}>
+              <Icon name="car" size={40} color="#201B1B" style={styles.icon} />
+            </Pressable>
+
+            <Pressable onPress={() => {
+                setModalVisible(!modalVisible)
+                setRecyclingVisible(true)}
+            }>
+              <Icon name="recycle" size={40} color="#201B1B" style={styles.icon} />
+            </Pressable>
+
+            <Pressable
+              onPress={() => setModalVisible(!modalVisible)}>
+              <Icon name="close" size={40} color="#201B1B" style={styles.icon} />
+            </Pressable>
+
+          </View>
+        </View>
+        </Modal>
+
+      <EmissionModal visible={foodVisible}
+                     onRequestClose={(log) => {
+                      setFoodVisible(!foodVisible)
+                      setModalVisible(!modalVisible)
+                    }}  
+                    title={"How much meat did you consume today?"}
+                    saveData={(log) => saveFoodLog(log)}
+                    />
+      <EmissionModal visible={transportationVisible}
+                     onRequestClose={() => {
+                      setTransportationVisible(!transportationVisible)
+                      setModalVisible(!modalVisible)
+                    }}  
+                    title={"How many miles did you drive today?"}
+                    saveData={(log) => saveTransportationLog(log)}
+                    />
+      <EmissionModal visible={recyclingVisible}
+                     onRequestClose={() => {
+                      setRecyclingVisible(!recyclingVisible)
+                      setModalVisible(!modalVisible)
+                    }}  
+                    title={"How much did you recycle today?"}
+                    saveData={(log) => saveRecyclingLog(log)}
+                    />
+
+        <Pressable style={styles.button} onPress={() => setModalVisible(true)}>
+        <Text style={styles.text}>Record Emissions</Text>
+        </Pressable>
+    </KeyboardAvoidingView>
+    
+  )
+}
+
+export default RecordEmission;
+
+const styles = StyleSheet.create({
+    centeredView: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginTop: 22,
+        justifyContent: 'flex-end',
+        marginBottom: 48 ,
+        backgroundColor: '#D8F3DC',
+      },
+
+      modalView: {
+        backgroundColor: '#D8F3DC',
+        alignItems: 'center',
+      },
+      modal: {
+        backgroundColor: '#D8F3DC',
+      },
+      modalText: {
+        fontSize: 18,
+        fontWeight: 'bold',
+        marginBottom: 20,
+      },
+    button: {
+        borderRadius: 4,
+        borderWidth: 2,
+        borderColor: 'black',
+        padding: 10,
+        margin: 10,
+        elevation: 2,
+        width: 120,
+      },
+
+      modalText: {
+        marginBottom: 15,
+        textAlign: 'center',
+      },
+      icon: {
+        marginHorizontal: 20,
+        padding: 20,
+
+      },
+    
+})


### PR DESCRIPTION
Created two components that allow the users to track their daily emissions.

EmissionModal.js is a component that takes in props to display the Emission that the user selected. It is used multiple times in RecordEmission.js.

RecordEmission.js initially only displays a record emission button(lines 94-96). After it is clicked a modal pops up with 3 icons that the user can click. Based on which icon is clicked the corresponding EmissionModal component is rendered.

I went ahead and added the RecordEmission component to ProgressScreen.js. This can be moved around as needed, also both components can be moved into a separate component file as long as their import paths are updated in RecordEmission.js and ProgressScreen.js.

TODO: Still need to implement unit tests and connect to the back end. 