### PR TITLE
Added BrowserScreen.js for website embedding

### DIFF
--- a/Carbon/navigation/screens/Browser/BrowserScreen.js
+++ b/Carbon/navigation/screens/Browser/BrowserScreen.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import {WebView} from 'react-native-webview'
+import{ View, TouchableOpacity, Text} from 'react-native'
+
+const BackButton = ({navigation}) =>
+<TouchableOpacity onPress={() => {
+    navigation.goBack()
+}}>
+    <Text>&lt; Back</Text>
+</TouchableOpacity>
+
+
+export default class BrowserScreen extends Component {
+
+    // static navigationOptions = ({ navigation }) => ({
+    //     title: 'Browser',
+    //     headerLeft: <BackButton navigation={navigation}/>
+    // })
+
+    render() {
+        return(
+            <View style = {{flex:1}}>
+                <WebView source = {{ 
+                    uri: 'https://chat.openai.com/chat'
+                    //uri: this.props.navigation.state.parms.url this will be used later with other links
+                }}
+                style={{flex:1}}
+                />
+            </View>
+        )
+    }
+}

--- a/Carbon/navigation/screens/Main/MainContainer.js
+++ b/Carbon/navigation/screens/Main/MainContainer.js
@@ -10,7 +10,8 @@ import { Colors } from '../../../colors/Colors';
 import { IconNames } from './IconNames';
 
 import { ScreenNames } from './ScreenNames';
-import { HomeScreen, ProgressScreen, ForumScreen, RankingScreen, SettingsScreen, AddProgress } from '../../screens';
+import { HomeScreen, ProgressScreen, ForumScreen, RankingScreen, SettingsScreen, AddProgress, BrowserScreen} from '../../screens';
+//import BrowserScreen from '../Browser/BrowserScreen';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -104,7 +105,8 @@ const ForumStack = ({ navigation }) => {
         <Stack.Navigator>
             <Stack.Screen
                 name={' '}
-                component={ForumScreen}
+                //component={ForumScreen}
+                component = {BrowserScreen}
                 options={{
                     headerShown: false, // Set to false for now until we need to implement headers for this screen
                 }}

--- a/Carbon/navigation/screens/Main/MainContainer.js
+++ b/Carbon/navigation/screens/Main/MainContainer.js
@@ -11,7 +11,6 @@ import { IconNames } from './IconNames';
 
 import { ScreenNames } from './ScreenNames';
 import { HomeScreen, ProgressScreen, ForumScreen, RankingScreen, SettingsScreen, AddProgress, BrowserScreen} from '../../screens';
-//import BrowserScreen from '../Browser/BrowserScreen';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();

--- a/Carbon/navigation/screens/Main/ScreenNames.js
+++ b/Carbon/navigation/screens/Main/ScreenNames.js
@@ -5,4 +5,5 @@ export const ScreenNames = {
     RANKING: 'Ranking',
     SETTINGS: 'Settings',
     ADD_PROGRESS: 'AddProgress',
+    BROWSER: 'Browser'
 };

--- a/Carbon/navigation/screens/index.js
+++ b/Carbon/navigation/screens/index.js
@@ -3,4 +3,5 @@ export {default as ProgressScreen} from './Progress/ProgressScreen';
 export {default as ForumScreen} from './Forum/ForumScreen';
 export {default as RankingScreen} from './Ranking/RankingScreen';
 export {default as SettingsScreen} from './Settings/SettingsScreen';
+export {default as BrowserScreen} from './Browser/BrowserScreen';
 // export {default as AddProgress} from './Progress/AddProgress';

--- a/Carbon/package-lock.json
+++ b/Carbon/package-lock.json
@@ -30,6 +30,7 @@
         "react-native-safe-area-context": "4.4.1",
         "react-native-svg": "13.4.0",
         "react-native-vector-icons": "^9.2.0",
+        "react-native-webview": "^11.26.1",
         "typescript": "^4.9.5",
         "victory-native": "^36.6.8"
       },
@@ -11712,6 +11713,27 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "11.26.1",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.26.1.tgz",
+      "integrity": "sha512-hC7BkxOpf+z0UKhxFSFTPAM4shQzYmZHoELa6/8a/MspcjEP7ukYKpuSUTLDywQditT8yI9idfcKvfZDKQExGw==",
+      "dependencies": {
+        "escape-string-regexp": "2.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-webview/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/react-native/node_modules/@react-native/normalize-color": {

--- a/Carbon/package.json
+++ b/Carbon/package.json
@@ -31,6 +31,7 @@
     "react-native-safe-area-context": "4.4.1",
     "react-native-svg": "13.4.0",
     "react-native-vector-icons": "^9.2.0",
+    "react-native-webview": "^11.26.1",
     "typescript": "^4.9.5",
     "victory-native": "^36.6.8"
   },


### PR DESCRIPTION
I've created a new component called BrowserScreen.js which allows for easy embedding of websites into the app. This component will be particularly useful in the future when we want to display articles in the education forum section.

I've also added this new component to the navigation tab for easy access. Additionally, I've already used the BrowserScreen.js component to embed our class website for senior design into the education section.

Overall, these changes will greatly improve the user experience by allowing easy access to external content within the app, and laying the foundation for future enhancements to the education section.

Please review and merge at your convenience.

Thank you!