### PR TITLE
Add `ScreenDimensionsProvider` Hook.

### DIFF
--- a/Carbon/App.js
+++ b/Carbon/App.js
@@ -1,9 +1,13 @@
 import * as React from 'react';
+import { ScreenDimensionsProvider } from './hooks/ScreenDimensionsProvider';
 import MainContainer from './navigation/screens/Main/MainContainer';
 
-function App(){
+function App() {
   return (
-    <MainContainer /> //links to MainContainer.js in navigation folder
+    //links to MainContainer.js in navigation folder
+    <ScreenDimensionsProvider>
+      <MainContainer />
+    </ScreenDimensionsProvider>
   )
 }
 

--- a/Carbon/components/ChartData.js
+++ b/Carbon/components/ChartData.js
@@ -167,7 +167,7 @@ export const KeyFactors = () => {
 
     if (value == 0) return null;
     return (
-      <View style={[styleBar.category, {alignContent: 'flex-end', flex: 1}]}>
+      <View style={[styleBar.category, {marginVertical: 0, alignContent: 'flex-end', flex: 1}]}>
         { value > 0 && (
           <>{bad_change}{diff}</>
         )}

--- a/Carbon/hooks/ScreenDimensionsProvider.js
+++ b/Carbon/hooks/ScreenDimensionsProvider.js
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { Dimensions } from 'react-native';
+
+const ScreenDimensionsContext = createContext(null);
+
+export const useScreenDimensions = () => useContext(ScreenDimensionsContext);
+
+export const ScreenDimensionsProvider = ({ children }) => {
+  const [screenDimensions, setScreenDimensions] = useState(Dimensions.get('window'));
+
+  useEffect(() => {
+    const handleDimensionsChange = ({ window }) => {
+      setScreenDimensions(window);
+    };
+    Dimensions.addEventListener('change', handleDimensionsChange);
+    return () => {
+      Dimensions.removeEventListener('change', handleDimensionsChange);
+    };
+  }, []);
+
+  return (
+    <ScreenDimensionsContext.Provider value={screenDimensions}>
+      {children}
+    </ScreenDimensionsContext.Provider>
+  );
+};


### PR DESCRIPTION
- Created a new folder `hooks` to store any custom hooks created.
- Added `ScreenDimensionsProvider` to pass screen dimensions along to child elements in `MainContainer`.