### PR TITLE
Record emissions ranking system post refactor

### DIFF
--- a/Carbon/config/Api.js
+++ b/Carbon/config/Api.js
@@ -1,5 +1,5 @@
 // Testing Server
-export const API_URL = "http://192.168.0.232:3000/api/"
+export const API_URL = "http://localhost:3000/api/"
 
 // Deployed Server
 // export const API_URL = "http://Carbonserver-env.eba-pmpdtmpe.us-east-1.elasticbeanstalk.com/api/"

--- a/Carbon/config/Api.js
+++ b/Carbon/config/Api.js
@@ -1,5 +1,5 @@
 // Testing Server
-// export const API_URL = "http://localhost:3000/api/"
+export const API_URL = "http://192.168.0.232:3000/api/"
 
 // Deployed Server
-export const API_URL = "http://Carbonserver-env.eba-pmpdtmpe.us-east-1.elasticbeanstalk.com/api/"
+// export const API_URL = "http://Carbonserver-env.eba-pmpdtmpe.us-east-1.elasticbeanstalk.com/api/"

--- a/Carbon/navigation/screens/Progress/RecordEmission.js
+++ b/Carbon/navigation/screens/Progress/RecordEmission.js
@@ -25,7 +25,28 @@ export default function RecordEmissionScreen({navigation, route}) {
   }, [route.params]);
 
 
-  
+  // async function postRecycling() {
+  //   try {
+  //     const response = await fetch(`${API_URL}userEmissions`, {
+  //       method: 'POST',
+  //       headers:{
+  //         'Content-Type': 'application/json',
+  //         'secrettoken': await getToken(),
+  //       },
+  //       body: JSON.stringify({
+  //         diet_emissions: 0,
+  //         transport_emissions: 0,
+  //         total_emissions: recycledAmount,
+  //         lifestyle_emissions: recycledAmount,
+  //         home_emissions: 0,
+  //       })
+  //     })
+  //     .then(navigation.goBack());
+  //   } catch (error) {
+  //     console.error(error);
+  //   }
+  // }
+
 
   return (
     <View style={styles.centeredView}>

--- a/Carbon/navigation/screens/Progress/RecordEmission.js
+++ b/Carbon/navigation/screens/Progress/RecordEmission.js
@@ -1,24 +1,47 @@
 import {View, Text, StyleSheet, TouchableOpacity } from 'react-native'
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { React } from 'react';
+import { React, useCallback, useEffect } from 'react';
 import { ScreenNames } from '../Main/ScreenNames';
-export default function RecordEmissionScreen({navigation}) {
+import { useState } from 'react';
+export default function RecordEmissionScreen({navigation, route}) {
   
+  //Default value for the final submission that we post to the server
+  const [emissionsEntry, setEmissionsEntry] = useState({
+        transport_emissions : null, 
+        total_emissions : null,
+        lifestyle_emissions : null, 
+        diet_emissions : null, 
+        home_emissions : null
+  });
+
+  //When we get a "returningEmissionsEntry", which is returned by the category screens, we update our own
+  //EmissionsEntry state variable to reflect the new update. Originally passing the stateSetter was planned
+  //But we get warnings about possible bugs, so we're passing by value and not changing state.
+  useEffect(() => { 
+    if(route.params?.returningEmissionsEntry){
+      console.log(route.params.returningEmissionsEntry)
+      setEmissionsEntry(route.params.returningEmissionsEntry);
+    }
+  }, [route.params]);
+
+
+  
+
   return (
     <View style={styles.centeredView}>
       <View style={styles.modalView}>  
         <TouchableOpacity onPress={() => {
-            navigation.navigate(ScreenNames.FOOD)
+            navigation.navigate(ScreenNames.FOOD, {sentEmissionsEntry : emissionsEntry})
         }}>
           <Icon name="cutlery" size={40} color="#201B1B" style={styles.icon} testID="cutlery-icon"/>
         </TouchableOpacity> 
         <TouchableOpacity onPress={() => {
-            navigation.navigate(ScreenNames.TRANSPORTATION)
+            navigation.navigate(ScreenNames.TRANSPORTATION, {sentEmissionsEntry : emissionsEntry})
         }}>
           <Icon name="car" size={40} color="#201B1B" style={styles.icon} testID="car-icon" />
         </TouchableOpacity> 
         <TouchableOpacity onPress={() => {
-            navigation.navigate(ScreenNames.RECYCLING)
+            navigation.navigate(ScreenNames.RECYCLING, {sentEmissionsEntry : emissionsEntry})
         }}>
           <Icon name="recycle" size={40} color="#201B1B" style={styles.icon} testID="recycle-icon" />
         </TouchableOpacity> 

--- a/Carbon/navigation/screens/Progress/RecordEmission.js
+++ b/Carbon/navigation/screens/Progress/RecordEmission.js
@@ -52,8 +52,8 @@ export default function RecordEmissionScreen({navigation, route}) {
         navigation.goBack();
       }
       //if second post for the day - alert and also go back
-      else if(response.status === 400){
-        throw new Error(`You can only upload results once a day :(`);
+      else if(response.status === 204){
+        alert(`You can only upload results once a day :(`);
         navigation.goBack(); 
       }
       //Alert on bad request - should only see on testing 

--- a/Carbon/navigation/screens/Progress/RecordEmission.js
+++ b/Carbon/navigation/screens/Progress/RecordEmission.js
@@ -27,27 +27,35 @@ export default function RecordEmissionScreen({navigation, route}) {
   }, [route.params]);
 
 
-  // async function postRecycling() {
-  //   try {
-  //     const response = await fetch(`${API_URL}userEmissions`, {
-  //       method: 'POST',
-  //       headers:{
-  //         'Content-Type': 'application/json',
-  //         'secrettoken': await getToken(),
-  //       },
-  //       body: JSON.stringify({
-  //         diet_emissions: 0,
-  //         transport_emissions: 0,
-  //         total_emissions: recycledAmount,
-  //         lifestyle_emissions: recycledAmount,
-  //         home_emissions: 0,
-  //       })
-  //     })
-  //     .then(navigation.goBack());
-  //   } catch (error) {
-  //     console.error(error);
-  //   }
-  // }
+  async function postResults() { 
+    try{
+      let e = emissionsEntry; 
+      emissionsEntry.total_emissions = e.diet_emissions + e.home_emissions + e.lifestyle_emissions + e.transport_emissions
+
+      if(emissionsEntry.total_emissions === 0 ) throw new Error(`Please Upload at least one Emission Category`);
+
+      const response = await fetch(`${API_URL}userEmissions`, {
+        method: 'POST',
+        headers:{
+          'Content-Type': 'application/json',
+          'secrettoken': await getToken(),
+        },
+        body : JSON.stringify(emissionsEntry)
+      });
+      if(response.status === 200) {
+        console.log("Successful Post!");
+        navigation.goBack();
+      }
+      else if(response.status === 400){
+        throw new Error(`You can only upload results once a day :(`);
+      }
+      else if(response.status === 404){
+        throw new Error(`Client ID Not Found`);
+      }
+    } catch(err) {
+      alert(err.message)
+    }
+  }
 
 
   return (
@@ -69,9 +77,9 @@ export default function RecordEmissionScreen({navigation, route}) {
           <Icon name="recycle" size={40} color="#201B1B" style={styles.icon} testID="recycle-icon" />
         </TouchableOpacity> 
         <TouchableOpacity
-          onPress={() => navigation.goBack()}
+          onPress={() => {postResults()}}
         >
-          <Icon name="close" size={40} color="#201B1B" style={styles.icon} testID="close-icon" />
+          <Icon name="cloud-upload" size={40} color="#201B1B" style={styles.icon} testID="save-and-exit-icon" />
         </TouchableOpacity>
       </View>
           

--- a/Carbon/navigation/screens/Progress/RecordEmission.js
+++ b/Carbon/navigation/screens/Progress/RecordEmission.js
@@ -3,6 +3,8 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import { React, useCallback, useEffect } from 'react';
 import { ScreenNames } from '../Main/ScreenNames';
 import { useState } from 'react';
+import {API_URL} from '../../../config/Api';
+import { getToken } from '../../../util/LoginManager';
 export default function RecordEmissionScreen({navigation, route}) {
   
   //Default value for the final submission that we post to the server

--- a/Carbon/navigation/screens/Progress/RecordEmission.js
+++ b/Carbon/navigation/screens/Progress/RecordEmission.js
@@ -9,11 +9,11 @@ export default function RecordEmissionScreen({navigation, route}) {
   
   //Default value for the final submission that we post to the server
   const [emissionsEntry, setEmissionsEntry] = useState({
-        transport_emissions : null, 
-        total_emissions : null,
-        lifestyle_emissions : null, 
-        diet_emissions : null, 
-        home_emissions : null
+        transport_emissions : 0, 
+        total_emissions : 0,
+        lifestyle_emissions : 0, 
+        diet_emissions : 0, 
+        home_emissions : 0
   });
 
   //When we get a "returningEmissionsEntry", which is returned by the category screens, we update our own
@@ -27,13 +27,17 @@ export default function RecordEmissionScreen({navigation, route}) {
   }, [route.params]);
 
 
+  //Posts the results, on a successfull post it will leave the screen
   async function postResults() { 
     try{
+      //for conciseness, emissionsEntry total is just the sum of the others
       let e = emissionsEntry; 
       emissionsEntry.total_emissions = e.diet_emissions + e.home_emissions + e.lifestyle_emissions + e.transport_emissions
 
+      //Check if at least one emission was entered
       if(emissionsEntry.total_emissions === 0 ) throw new Error(`Please Upload at least one Emission Category`);
 
+      //post emission to server
       const response = await fetch(`${API_URL}userEmissions`, {
         method: 'POST',
         headers:{
@@ -42,13 +46,17 @@ export default function RecordEmissionScreen({navigation, route}) {
         },
         body : JSON.stringify(emissionsEntry)
       });
+      //exit screen on successful request
       if(response.status === 200) {
         console.log("Successful Post!");
         navigation.goBack();
       }
+      //if second post for the day - alert and also go back
       else if(response.status === 400){
         throw new Error(`You can only upload results once a day :(`);
+        navigation.goBack(); 
       }
+      //Alert on bad request - should only see on testing 
       else if(response.status === 404){
         throw new Error(`Client ID Not Found`);
       }
@@ -56,6 +64,8 @@ export default function RecordEmissionScreen({navigation, route}) {
       alert(err.message)
     }
   }
+
+
 
 
   return (

--- a/Carbon/navigation/screens/Progress/RecordFood.js
+++ b/Carbon/navigation/screens/Progress/RecordFood.js
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import {Picker} from '@react-native-picker/picker';
 import {Colors} from '../../../colors/Colors';
-import { API_URL } from '../../../config/Api';
-import { getToken } from '../../../util/LoginManager';
+import { ScreenNames } from '../Main/ScreenNames';
 
-const RecordFood = ({ navigation }) => {
+const RecordFood = ({ navigation, route }) => {
   const [consumption, setConsumption] = useState(0);
+  const [emissionsEntry, setEmissionsEntry] = useState();
   const funFacts = [
     "The average American diet generates approximately 2.5 metric tons of carbon dioxide emissions per year.",
     "A meat-based diet generates 2.5 times more carbon emissions than a vegetarian diet.",
@@ -19,27 +19,17 @@ const RecordFood = ({ navigation }) => {
     const randomIndex = Math.floor(Math.random() * funFacts.length);
     return funFacts[randomIndex];
   }
-  async function postFood() {
-    try {
-      const response = await fetch(`${API_URL}userEmissions`, {
-        method: 'POST',
-        headers:{
-          'Content-Type': 'application/json',
-          'secrettoken': await getToken(),
-        },
-        body: JSON.stringify({
-          diet_emissions: consumption,
-          transport_emissions: 0,
-          total_emissions: consumption,
-          lifestyle_emissions: 0,
-          home_emissions: 0,
-        })
-      })
-      .then(navigation.goBack());
-    } catch (error) {
-      console.error(error);
-    }
-  }
+
+  //Update our parameter to send back when the consumption state variable changes 
+  useEffect( () => {
+    if(consumption !== null)
+    setEmissionsEntry({
+        ...route.params.sentEmissionsEntry,
+        diet_emissions:consumption
+    })
+  }, [consumption])
+
+
   return (
     <View style={styles.container}>
       <View style={styles.funfact}>
@@ -59,8 +49,8 @@ const RecordFood = ({ navigation }) => {
             <Picker.Item label="0.75 lbs" value={0.75} />
             <Picker.Item label="1 lb" value={1} />
         </Picker>
-        <TouchableOpacity style={styles.button} onPress={postFood}>
-          <Text style={styles.buttonText}>Save</Text>
+        <TouchableOpacity style={styles.button} onPress={() => navigation.navigate(ScreenNames.RECORD_EMISSION, {returningEmissionsEntry : emissionsEntry})}>
+          <Text style={styles.buttonText}>Save & Return</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/Carbon/navigation/screens/Progress/RecordRecycling.js
+++ b/Carbon/navigation/screens/Progress/RecordRecycling.js
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity, Switch} from 'react-native';
 import {Picker} from '@react-native-picker/picker';
 import {Colors} from '../../../colors/Colors';
-import {API_URL} from '../../../config/Api';
-import { getToken } from '../../../util/LoginManager';
+import { ScreenNames } from '../Main/ScreenNames';
 
-const RecordRecycling = ({ navigation }) => {
+
+const RecordRecycling = ({ navigation, route }) => {
+  const [emissionsEntry, setEmissionsEntry] = useState();
   const [recycledAmount, setRecycledAmount] = useState(0);
   const [reusableBags, setReusableBags] = useState(false);
   const funFacts = [
@@ -19,27 +20,18 @@ const RecordRecycling = ({ navigation }) => {
     const randomIndex = Math.floor(Math.random() * funFacts.length);
     return funFacts[randomIndex];
   }
-  async function postRecycling() {
-    try {
-      const response = await fetch(`${API_URL}userEmissions`, {
-        method: 'POST',
-        headers:{
-          'Content-Type': 'application/json',
-          'secrettoken': await getToken(),
-        },
-        body: JSON.stringify({
-          diet_emissions: 0,
-          transport_emissions: 0,
-          total_emissions: recycledAmount,
-          lifestyle_emissions: recycledAmount,
-          home_emissions: 0,
-        })
-      })
-      .then(navigation.goBack());
-    } catch (error) {
-      console.error(error);
-    }
-  }
+  
+
+  //Update our parameter to send back when the consumption state variable changes 
+  useEffect(() => {
+    if(recycledAmount !== null)
+    setEmissionsEntry({
+        ...route.params.sentEmissionsEntry,
+        lifestyle_emissions : recycledAmount
+    })
+  }, [recycledAmount])
+  
+  
 
   return (
     <View style={styles.container}>
@@ -66,7 +58,7 @@ const RecordRecycling = ({ navigation }) => {
           onValueChange={(value) => setReusableBags(value)}
         />
       </View>
-      <TouchableOpacity style={styles.button} onPress={postRecycling}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate(ScreenNames.RECORD_EMISSION, {returningEmissionsEntry : emissionsEntry})}>
         <Text style={styles.buttonText}>Save</Text>
       </TouchableOpacity>      
     </View>

--- a/Carbon/navigation/screens/Progress/RecordTransportation.js
+++ b/Carbon/navigation/screens/Progress/RecordTransportation.js
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View, Switch, TouchableOpacity } from 'react-native';
 import {Picker} from '@react-native-picker/picker';
 import {Colors} from '../../../colors/Colors';
-import {API_URL} from '../../../config/Api';
-import { getToken } from '../../../util/LoginManager';
+import { ScreenNames } from '../Main/ScreenNames';
 
-const RecordTransportation = ({ navigation }) => {
+
+const RecordTransportation = ({ navigation, route }) => {
+  const [emissionsEntry, setEmissionsEntry] = useState({});
   const [milesDriven, setMilesDriven] = useState(0);
   const [publicTransportationUsed, setPublicTransportationUsed] = useState(false);
   const [bikeUsed, setBikeUsed] = useState(false);
@@ -20,27 +21,17 @@ const RecordTransportation = ({ navigation }) => {
     const randomIndex = Math.floor(Math.random() * funFacts.length);
     return funFacts[randomIndex];
   }
-  async function postTransportation() {
-    try {
-      const response = await fetch(`${API_URL}userEmissions`, {
-        method: 'POST',
-        headers:{
-          'Content-Type': 'application/json',
-          'secrettoken': await getToken(),
-        },
-        body: JSON.stringify({
-          diet_emissions: 0,
-          transport_emissions: milesDriven,
-          total_emissions: milesDriven,
-          lifestyle_emissions: 0,
-          home_emissions: 0,
-        })
-      })
-      .then(navigation.goBack());
-    } catch (error) {
-      console.error(error);
-    }
-  }
+
+
+  //Update our parameter to send back when the consumption state variable changes 
+  useEffect(() => {
+    if(milesDriven !== null)
+    setEmissionsEntry({
+        ...route.params.sentEmissionsEntry,
+        transport_emissions : milesDriven
+    })
+  }, [milesDriven])
+
 
   return (
     <View style={styles.container}>
@@ -81,7 +72,7 @@ const RecordTransportation = ({ navigation }) => {
           onValueChange={(value) => setBikeUsed(value)}
         />
       </View>
-      <TouchableOpacity style={styles.button} onPress={postTransportation}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate(ScreenNames.RECORD_EMISSION, {returningEmissionsEntry : emissionsEntry})}>
         <Text style={styles.buttonText}>Save</Text>
       </TouchableOpacity>
     </View>


### PR DESCRIPTION
Hey all, this is a fairly light refactoring of the recordEmissions component so that it can work to be compatible with the current ranking system ~ although I can still rework it to be cumulative. 

Anyhow, here are the changes made 
Frontend
- RecordEmissions now has a state variable that is updated with parameters sent across the stack-based subcomponents of recording subcategories. 
  - Post request is now in RecordEmission.js this is accompanied with a Cloud-Saving Icon that posts your data
  -  Alerts user if they have an invalid request or have more than one post for the day.
  - Calls to stack-based component pass the current state is an a parameter, where child components are now responsible with  
     updating the current state variable as a parameter sent back. Oddly sending functions allows a warning for maintaining state, should we want the user to ever go to a page after completely shutting off the app. 
 
Backend 
 - Post request for the user emission will now check the entries that were posted today, and will return a 204 response if we have already have today's entry
 - UpdateScore was commented out and removed in one of the earlier PRs, this is now placed back in.

Let me know what you think about this, and I'll make any changes necessary