### PR TITLE
Create CI/CD pipeline yaml file

### DIFF
--- a/Carbon/.github/workflows/test.yaml
+++ b/Carbon/.github/workflows/test.yaml
@@ -1,0 +1,29 @@
+name: Carbon CI/CD Pipeline v1.00
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run tests
+        run: npm test

--- a/Carbon/.github/workflows/test.yaml
+++ b/Carbon/.github/workflows/test.yaml
@@ -1,9 +1,6 @@
 name: Carbon CI/CD Pipeline v1.00
 
-on:
-  pull_request:
-    branches:
-      - main
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request will create a CI/CD pipeline that runs the Jest tests on our client side. This may or may not work first attempt and I would like to add Docker images in order to keep us all on the same image constantly. I'd also like to add test coverage at 85% required.

It will be harder to get PRs in after this as you will need to update unit tests if you break anything when trying to get a PR in but this will be helpful in retaining quality.

