### PR TITLE
Db update ranking categories titles and profile pictures

### DIFF
--- a/Carbon/config/Api.js
+++ b/Carbon/config/Api.js
@@ -1,5 +1,5 @@
 // Testing Server
-export const API_URL = "http://localhost:3000/api/"
+export const API_URL = "http://192.168.0.232:3000/api/"
 
 // Deployed Server
 // export const API_URL = "http://Carbonserver-env.eba-pmpdtmpe.us-east-1.elasticbeanstalk.com/api/"

--- a/Carbon/config/Api.js
+++ b/Carbon/config/Api.js
@@ -1,5 +1,5 @@
 // Testing Server
-export const API_URL = "http://192.168.0.232:3000/api/"
+export const API_URL = "http://localhost:3000/api/"
 
 // Deployed Server
 // export const API_URL = "http://Carbonserver-env.eba-pmpdtmpe.us-east-1.elasticbeanstalk.com/api/"

--- a/Carbon/util/SustainabilityScoreProfileView.js
+++ b/Carbon/util/SustainabilityScoreProfileView.js
@@ -1,0 +1,48 @@
+//Titles for the SustainabilityScores - Server only stores the ints, Client side will translate them to the titles and path into the picture,
+//  Adding A's and An's to avoid future formatting annoyances
+//  NOTE: users MUST provide their own relative path to the Carbon directory
+export const SustainabilityScoreProfileView = [
+    {
+        title : "An Eco Opponent",
+        picture : "assets/rank-icons/rank-icon-1.png"
+    },
+    {
+        title : "A Climate Change Denier",
+        picture : "assets/rank-icons/rank-icon-1.png"
+    },
+    {
+        title : "A Sustainability Saboteur",
+        picture : "assets/rank-icons/rank-icon-2.png"
+    },
+    {
+        title : "A Planet Polluter",
+        picture : "assets/rank-icons/rank-icon-2.png"
+    },
+    
+    {
+        title : "A Carbon Neutral",
+        picture : "assets/rank-icons/rank-icon-3.png"
+    },
+    {
+        title : "A Climate Conscious",
+        picture : "assets/rank-icons/rank-icon-3.png"
+    },
+    {
+        title : "A Renewable Energy Enthusiast",
+        picture : "assets/rank-icons/rank-icon-4.png"
+    },
+    {
+        title : "A Green Leader",
+        picture : "assets/rank-icons/rank-icon-4.png"
+    },
+    {
+        title : "A Sustainability Titan",
+        picture : "assets/rank-icons/rank-icon-5.png"
+    },
+    {
+        title : "An Eco Ambassador",
+        picture : "assets/rank-icons/rank-icon-5.png"
+    }
+]; 
+
+export default {SustainabilityScoreProfileView}; 

--- a/Carbon/util/SustainabilityScoreProfileView.js
+++ b/Carbon/util/SustainabilityScoreProfileView.js
@@ -1,46 +1,45 @@
 //Titles for the SustainabilityScores - Server only stores the ints, Client side will translate them to the titles and path into the picture,
-//  Adding A's and An's to avoid future formatting annoyances
 //  NOTE: users MUST provide their own relative path to the Carbon directory
 export const SustainabilityScoreProfileView = [
     {
-        title : "An Eco Opponent",
+        title : "Eco Opponent",
         picture : "assets/rank-icons/rank-icon-1.png"
     },
     {
-        title : "A Climate Change Denier",
+        title : "Climate Change Denier",
         picture : "assets/rank-icons/rank-icon-1.png"
     },
     {
-        title : "A Sustainability Saboteur",
+        title : "Sustainability Saboteur",
         picture : "assets/rank-icons/rank-icon-2.png"
     },
     {
-        title : "A Planet Polluter",
+        title : "Planet Polluter",
         picture : "assets/rank-icons/rank-icon-2.png"
     },
     
     {
-        title : "A Carbon Neutral",
+        title : "Carbon Neutral",
         picture : "assets/rank-icons/rank-icon-3.png"
     },
     {
-        title : "A Climate Conscious",
+        title : "Climate Conscious",
         picture : "assets/rank-icons/rank-icon-3.png"
     },
     {
-        title : "A Renewable Energy Enthusiast",
+        title : "Renewable Energy Enthusiast",
         picture : "assets/rank-icons/rank-icon-4.png"
     },
     {
-        title : "A Green Leader",
+        title : "Green Leader",
         picture : "assets/rank-icons/rank-icon-4.png"
     },
     {
-        title : "A Sustainability Titan",
+        title : "Sustainability Titan",
         picture : "assets/rank-icons/rank-icon-5.png"
     },
     {
-        title : "An Eco Ambassador",
+        title : "Eco Ambassador",
         picture : "assets/rank-icons/rank-icon-5.png"
     }
 ]; 

--- a/Server/models/User.js
+++ b/Server/models/User.js
@@ -48,6 +48,26 @@ const User = sequelize.define('user', {
         type : DataTypes.INTEGER.UNSIGNED,
         allowNull : false, 
         defaultValue: 0 
+    },
+    transport_score : {
+        type : DataTypes.INTEGER.UNSIGNED,
+        allowNull : false, 
+        defaultValue: 0 
+    },
+    lifestyle_score : {
+        type : DataTypes.INTEGER.UNSIGNED,
+        allowNull : false, 
+        defaultValue: 0 
+    },
+    diet_score : {
+        type : DataTypes.INTEGER.UNSIGNED,
+        allowNull : false, 
+        defaultValue: 0 
+    },
+    home_score : {
+        type : DataTypes.INTEGER.UNSIGNED,
+        allowNull : false, 
+        defaultValue: 0 
     }
 }, {
     hooks: {

--- a/Server/models/User.js
+++ b/Server/models/User.js
@@ -39,6 +39,11 @@ const User = sequelize.define('user', {
         allowNull : true,       //Should only be true when the user is first created
         defaultValue : null 
     },
+    avatar_index : {
+        type : DataTypes.TINYINT.UNSIGNED,
+        allowNull : false, 
+        defaultValue : 1
+    },
     global_score : {
         type : DataTypes.INTEGER.UNSIGNED,
         allowNull : false, 

--- a/Server/utils/UpdateScore.js
+++ b/Server/utils/UpdateScore.js
@@ -50,8 +50,7 @@ async function UpdateScore(ID) {
     let score_offset = 0; 
     let login_bonus = 0.10; 
     let newScores = [user.global_score, user.transport_score, user.lifestyle_score, user.diet_score, user.home_score];
-    console.log("\n\nOld Scores:\n");
-    console.log(newScores);
+
     let individualEmissions = 
         [
             emission_entries[0].total_emissions, emission_entries[0].transport_emissions, 
@@ -81,11 +80,6 @@ async function UpdateScore(ID) {
         if(newScores[i] > MAX_SCORE) newScores[i] = MAX_SCORE;
     }
     
-    console.log("Individual Emissions:\n");
-    console.log(individualEmissions);
-    console.log("\n\nNew Scores");
-    console.log(newScores)
-
     await user_table.update(
         {
             global_score : newScores[0],

--- a/Server/utils/UpdateScore.js
+++ b/Server/utils/UpdateScore.js
@@ -7,6 +7,11 @@ var user_table = require('../models/User.js')
 //Prevent overflow in MySQL DB 
 const MAX_SCORE = 100_000_000
 
+/**
+ * 
+ * @param {Number} ID  
+ * @returns - No value returned, instead will update database based on recorded emissions 
+ */
 async function UpdateScore(ID) {
     
     //get total_emissions, the only valid one is today. and the next earliest one
@@ -41,11 +46,71 @@ async function UpdateScore(ID) {
 
 
     //shorthand
-    let globalScore = user.global_score;
-    let goal = user.goal;
-    let goal_bonus = 0;
+    let goal_bonus = calculateGoalBonus(user.goal);
+    let score_offset = 0; 
+    let login_bonus = 0.10; 
+    let newScores = [user.global_score, user.transport_score, user.lifestyle_score, user.diet_score, user.home_score];
+    console.log("\n\nOld Scores:\n");
+    console.log(newScores);
+    let individualEmissions = 
+        [
+            emission_entries[0].total_emissions, emission_entries[0].transport_emissions, 
+            emission_entries[0].lifestyle_emissions, emission_entries[0].diet_emissions, 
+            emission_entries[0].home_emissions    
+        ]
 
 
+    //Check if youre track for your yearly carbon emissions
+    if(emission_entries[0].total_emissions*365 <= projected_emissions) {
+        score_offset = 500*(1+login_bonus+goal_bonus);
+    }
+    else {
+        score_offset -= 300*(1-login_bonus);    
+    }
+
+    //Let each emission 
+    for(let i = 0; i < newScores.length; i++) {
+        if(i == 0) {
+            newScores[i]+=score_offset;
+        }
+        else{
+            newScores[i]+=score_offset*(1-(individualEmissions[i]/individualEmissions[0]));
+        }
+    
+        if(newScores[i] < 0) newScores[i] = 0;
+        if(newScores[i] > MAX_SCORE) newScores[i] = MAX_SCORE;
+    }
+    
+    console.log("Individual Emissions:\n");
+    console.log(individualEmissions);
+    console.log("\n\nNew Scores");
+    console.log(newScores)
+
+    await user_table.update(
+        {
+            global_score : newScores[0],
+            transport_score : newScores[1],
+            lifestyle_score: newScores[2],
+            diet_score : newScores[3], 
+            home_score : newScores[4] 
+        },
+        { where : { id : ID}}
+    );
+
+}
+
+
+
+
+/**
+ * 
+ * @param {Number} goal - goal set by user - Can be null
+ * @param {Array} emission_entries - a collection of at max, the two previous emission entries
+ * @returns - Goal bonus, which checks to see if a user has a goal, will return the percentage 
+ *            of the goal met]
+ */
+function calculateGoalBonus(goal, emission_entries) {
+    let goal_bonus = 0; 
 
     //get their previous emmissions only if they have a goal, and they
     //have an emission in the db to count
@@ -63,31 +128,7 @@ async function UpdateScore(ID) {
         }
     }
 
-
-
-    //TODO : Bring up adding a streak of logins into the user db table  
-    let login_bonus = 0.10;
-
-    //Check if youre track for your yearly carbon emissions
-    if(emission_entries[0].total_emissions*365 <= projected_emissions) {
-        globalScore += 500*(1+login_bonus+goal_bonus);
-    }
-    else {
-        globalScore -= 300*(1-login_bonus);    
-        if(globalScore < 0) globalScore = 0;
-    }
-
-    //Todo : Make function logarithmic after reaching level 50/30 - Will ask team which one would be preferred 
-    
-
-    //Put in table
-    if(globalScore > MAX_SCORE) globalScore = MAX_SCORE; //prevent overflow in the DB, Cut a little short but just 
-
-    await user_table.update(
-        {global_score : globalScore}, 
-        { where : { id : ID}}
-    );
+    return goal_bonus;
 
 }
-
 module.exports = UpdateScore


### PR DESCRIPTION
Relatively Brief PR but 3 Primary Additions

1. Added titles and a path to the corresponding sustainabilityScore icon in Carbon/util/SustainabilityScoreProfileView.js
  - Note: this JSON does not provide a relative path, and should be used in tandem with the components relative path to the Carbon/Carbon folder. 
2. user sequelize model is changed to reflect the new Database change 
  - avatar_index tinyint UN 
  - global_score int UN 
  - transport_score int UN 
  - lifestyle_score int UN 
  - diet_score int UN 
  - home_score int UN 
3. Backed Score Updated 
  - Subcategories are now incremented by the inverse proportion of how much it contributed to the overall emissions for that day
  - Slightly refactored to have the goal bonus be its own separate function, to avoid having too much in one function. 